### PR TITLE
Adds loading campaigns from local file

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,3 @@
+{
+  "import_campaigns": false
+}

--- a/debug_campaigns.json
+++ b/debug_campaigns.json
@@ -1,0 +1,3492 @@
+{
+  "campaigns": [
+    {
+        "id": "5052",
+        "title": "#BookItForward",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2401",
+        "title": "#ImABoss",
+        "hours": 0.5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "62",
+        "title": "#RealPrincess ",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2710",
+        "title": "#SuperStressFace",
+        "hours": 0.5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2693",
+        "title": "(Safe) Baby on Board?",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "5275",
+        "title": "1 in 3 of Us",
+        "hours": 0.5,
+        "primary_cause": "relationships",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "3501",
+        "title": "1 Star for Hate",
+        "hours": 0.5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "32",
+        "title": "13 Gallon Challenge",
+        "hours": 5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4173",
+        "title": "25,000 Women",
+        "hours": 0.5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3271",
+        "title": "50 Cans",
+        "hours": 10,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "6",
+        "title": "ABC Cleanup",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2046",
+        "title": "ABC Posters",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2092",
+        "title": "All-Access Petition",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2327",
+        "title": "Anti-Shaming Shutdown",
+        "hours": 1,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "4044",
+        "title": "Baby, It's Cold Inside",
+        "hours": 0.5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "57",
+        "title": "Babysitters Club",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "2273",
+        "title": "Backpack Attack",
+        "hours": 5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3513",
+        "title": "Bake Sales for Babies",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "1476",
+        "title": "Ban Binaries",
+        "hours": 5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "4121",
+        "title": "Band Together",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2737",
+        "title": "Band-Aid Brigade",
+        "hours": 1,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "4",
+        "title": "Banned Books Club",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "2272",
+        "title": "Barbie Bash",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "54",
+        "title": "Battle for the Bands",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2104",
+        "title": "Beat the Microbead",
+        "hours": 0.5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2461",
+        "title": "Birthday Mail",
+        "hours": 1,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3455",
+        "title": "Blessing Bags",
+        "hours": 5,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2093",
+        "title": "Blind Date Book Party",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "5394",
+        "title": "Bookmark Climate Change",
+        "hours": 1,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2238",
+        "title": "Box o' Books",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2427",
+        "title": "Breakup Bash",
+        "hours": 2,
+        "primary_cause": "relationships",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "1524",
+        "title": "Bubble Breaks",
+        "hours": 5,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "345",
+        "title": "Bullying Policy Makeover",
+        "hours": 2,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2070",
+        "title": "Bumble Bands",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2059",
+        "title": "Campfire Fighters",
+        "hours": 1,
+        "primary_cause": "disasters",
+        "secondary_causes": [
+            {
+                "id": "12",
+                "name": "disasters"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3280",
+        "title": "Can-Tribute",
+        "hours": 5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2227",
+        "title": "Career Tailgate",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "22",
+        "title": "Cell Phones for Survivors",
+        "hours": 5,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "5014",
+        "title": "Chai Impact",
+        "hours": 0,
+        "primary_cause": "",
+        "secondary_causes": [],
+        "action_type": ""
+    },
+    {
+        "id": "3413",
+        "title": "Clean and Green",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "55",
+        "title": "Cleanup Drills",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2978",
+        "title": "Climate Change Scav Hunt",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "12",
+                "name": "disasters"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "66",
+        "title": "Clothes for a Cause",
+        "hours": 10,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4148",
+        "title": "Clothing-Go-Round",
+        "hours": 5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2084",
+        "title": "College Confidential",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "362",
+        "title": "Comeback Clothes",
+        "hours": 5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "28",
+        "title": "Comics to the Rescue",
+        "hours": 5,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3302",
+        "title": "Cookin' It Old School",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "2915",
+        "title": "Cool Carol Crew",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4118",
+        "title": "Craziest Thing I Did to Save Money",
+        "hours": 0,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "56",
+        "title": "Crisis Crew",
+        "hours": 1,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "8",
+        "title": "Custodian Care",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "36",
+        "title": "Dancing With the Seniors",
+        "hours": 5,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4793",
+        "title": "Decade of Thanks",
+        "hours": 0,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "52",
+        "title": "Digital Debates",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "3446",
+        "title": "Dip Or...",
+        "hours": 10,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "958",
+        "title": "Dirty Dozen",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2465",
+        "title": "Diversify My Emoji",
+        "hours": 0.5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "63",
+        "title": "Dog Days of Winter",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3585",
+        "title": "Doggie DIY",
+        "hours": 5,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2906",
+        "title": "Doggy De-stresser",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "46",
+        "title": "Don't Be a Sucker",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "3812",
+        "title": "Don't Be Trashy",
+        "hours": 0,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2410",
+        "title": "Don't Kiss & Smell",
+        "hours": 1,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "1826",
+        "title": "Dress Up, Game On",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4142",
+        "title": "E-Waste Drive",
+        "hours": 10,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "5411",
+        "title": "Elephant Task Force",
+        "hours": 0.5,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "4001",
+        "title": "Epic Book Drive",
+        "hours": 0,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "48",
+        "title": "Faces of Immigration",
+        "hours": 0.5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2279",
+        "title": "Fake ID, Real Impact",
+        "hours": 1,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "4115",
+        "title": "Fed Up",
+        "hours": 0,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2015",
+        "title": "Fight Fire With Cookies",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "12",
+                "name": "disasters"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3509",
+        "title": "File Under Sexist",
+        "hours": 1,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2624",
+        "title": "Fish Bowl Baggies",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2440",
+        "title": "Flush It Down",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "41",
+        "title": "Flyer Away",
+        "hours": 2,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "73",
+        "title": "Food Forward",
+        "hours": 2,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "6",
+                "name": "homelessness"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "1820",
+        "title": "Freaky Friday Walks",
+        "hours": 10,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "24",
+        "title": "Free to Pee Petition",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "1526",
+        "title": "Fun in the (Real) Sun",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "3316",
+        "title": "Get Some (Consent)",
+        "hours": 0.5,
+        "primary_cause": "sex",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "3346",
+        "title": "Get-Well Cells",
+        "hours": 5,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3396",
+        "title": "GGW: Email",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3441",
+        "title": "GGW: Online Music",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3466",
+        "title": "GGW: Smartphones and Tablets",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "3397",
+        "title": "GGW: Social Media",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3394",
+        "title": "GGW: Video Chat",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3567",
+        "title": "Gift Card Give Back",
+        "hours": 2,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2041",
+        "title": "Girls Only Edit-a-Thon",
+        "hours": 5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2178",
+        "title": "Give a Spit About Cancer",
+        "hours": 0.5,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3427",
+        "title": "Give Us Your Balls",
+        "hours": 10,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "4974",
+        "title": "Glamorous Grannies",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "5034",
+        "title": "Grandparents Gone Wired",
+        "hours": 0,
+        "primary_cause": "",
+        "secondary_causes": [],
+        "action_type": ""
+    },
+    {
+        "id": "3827",
+        "title": "Green Your School",
+        "hours": 10,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2169",
+        "title": "Happy Howlidays",
+        "hours": 1,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2559",
+        "title": "Headhunters",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "3787",
+        "title": "Healing Oklahoma",
+        "hours": 2,
+        "primary_cause": "disasters",
+        "secondary_causes": [
+            {
+                "id": "12",
+                "name": "disasters"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2938",
+        "title": "Heart on Your Sleeve",
+        "hours": 0.5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "84",
+        "title": "Hello Kitties",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3625",
+        "title": "Holiday Party Animal",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2932",
+        "title": "Hot Dogs",
+        "hours": 1,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2086",
+        "title": "I Beat Bullying",
+        "hours": 0.5,
+        "primary_cause": "",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "13",
+        "title": "I Heart Dad",
+        "hours": 1,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "10",
+        "title": "I Want You to Quit Because...",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2186",
+        "title": "Improv Your School",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "74",
+        "title": "Incognito Cleanup",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2283",
+        "title": "Journey Jars",
+        "hours": 1,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2003",
+        "title": "Just Because",
+        "hours": 1,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "1536",
+        "title": "Justice for Elephants",
+        "hours": 1,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "886",
+        "title": "Kickball for All",
+        "hours": 5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2349",
+        "title": "Kid Books",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "2775",
+        "title": "Kidnapped Cosmetics",
+        "hours": 1,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2334",
+        "title": "LGBT HBD",
+        "hours": 5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2144",
+        "title": "Library Card Leviosa",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "2542",
+        "title": "Locked and Unloaded",
+        "hours": 1,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2005",
+        "title": "Love It Forward",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3755",
+        "title": "Love Letters ",
+        "hours": 0.5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "44",
+        "title": "Make Art, Save Art",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "4987",
+        "title": "Make It Happy",
+        "hours": 0.5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "61",
+        "title": "Meatless Mondays",
+        "hours": 10,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "53",
+        "title": "Mic Check Racism ",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "850",
+        "title": "Mind On My Money",
+        "hours": 0.5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "7",
+        "title": "Mirror Messages",
+        "hours": 1,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "15",
+        "title": "Momm-o-grams",
+        "hours": 0.5,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2240",
+        "title": "More Than a Score",
+        "hours": 0.5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "37",
+        "title": "Music March Out",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2075",
+        "title": "Musical Mix-Up",
+        "hours": 1,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "5114",
+        "title": "Nets for Nets",
+        "hours": 10,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4944",
+        "title": "Never Have I Ever",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "5069",
+        "title": "Not Breaking News",
+        "hours": 0.5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2805",
+        "title": "Notes From Shawn",
+        "hours": 0.5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2115",
+        "title": "Off-the-Street Ball",
+        "hours": 5,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "42",
+        "title": "Oppression Monopoly",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2532",
+        "title": "Paint For The Planet",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "3966",
+        "title": "Pantry Prep",
+        "hours": 15,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "14",
+        "title": "Parents Ride Shotty",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "43",
+        "title": "Party Animal",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2757",
+        "title": "Past Picture Perfect",
+        "hours": 1,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2930",
+        "title": "Patient Playbooks",
+        "hours": 1,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "955",
+        "title": "PB + Jam Slam",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "35",
+        "title": "Petition Plates",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2091",
+        "title": "Pineapple Push-Ups",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "21",
+                "name": "relationships"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "17",
+        "title": "Planting Par-tay",
+        "hours": 10,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "21",
+        "title": "Positivity Page",
+        "hours": 2,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "3573",
+        "title": "Prank It Forward",
+        "hours": 10,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "843",
+        "title": "Pregnancy Text",
+        "hours": 0.5,
+        "primary_cause": "sex",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "31",
+        "title": "Project Shutdown",
+        "hours": 0.5,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "18",
+        "title": "Prom for All",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "1516",
+        "title": "Purple Library Party",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2476",
+        "title": "Purrfect Halloween",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2149",
+        "title": "Puzzle Par-tay",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "1822",
+        "title": "Re-poppin' Bottles",
+        "hours": 10,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2324",
+        "title": "Read Outside the Lines",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "3616",
+        "title": "Resolution Wall",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3909",
+        "title": "Road to Recovery",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3731",
+        "title": "Road Trip Warriors",
+        "hours": 0.5,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2286",
+        "title": "ROGUE Magazine",
+        "hours": 1,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2259",
+        "title": "Safe Space Flag",
+        "hours": 2,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2078",
+        "title": "SAT Book Donation",
+        "hours": 0.5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "830",
+        "title": "Save Our Pets",
+        "hours": 2,
+        "primary_cause": "disasters",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "12",
+                "name": "disasters"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "1819",
+        "title": "Say It With Songs",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "75",
+        "title": "Say What?",
+        "hours": 5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "839",
+        "title": "School Board Tweeter",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "5356",
+        "title": "School Insider",
+        "hours": 2,
+        "primary_cause": "",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "19",
+        "title": "School Standstill",
+        "hours": 0.5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "822",
+        "title": "School the Vote",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "5140",
+        "title": "Screen Statements",
+        "hours": 1,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2072",
+        "title": "Scrub-A-Dub Dog",
+        "hours": 5,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "3624",
+        "title": "Sea Turtle Street Sweep",
+        "hours": 0.5,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "4264",
+        "title": "Search for Specs",
+        "hours": 0.5,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2277",
+        "title": "Seaside Stakeout",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "819",
+        "title": "Seed Bombs Away",
+        "hours": 1,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "9",
+        "title": "Senior Socials",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "4946",
+        "title": "Seniorpalooza",
+        "hours": 5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3539",
+        "title": "Sexy or Sexist?",
+        "hours": 1,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "58",
+        "title": "Shelter Pet PR",
+        "hours": 5,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3590",
+        "title": "Shower Songs",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2933",
+        "title": "Smiles for Soldiers",
+        "hours": 0.5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2544",
+        "title": "Social Media Makeover",
+        "hours": 2,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "3496",
+        "title": "Soldier Statements",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "2487",
+        "title": "Solitary Statements",
+        "hours": 2,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "2063",
+        "title": "Soup Something",
+        "hours": 5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "3773",
+        "title": "Souper Drive",
+        "hours": 5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2175",
+        "title": "Speak-Out Week",
+        "hours": 1,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "76",
+        "title": "Stacks on Stacks",
+        "hours": 5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3345",
+        "title": "Stand Up Guy",
+        "hours": 0.5,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "4139",
+        "title": "Staples for Students",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3726",
+        "title": "Step Up to Bullying",
+        "hours": 2,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "3743",
+        "title": "Storm Drain Street Art",
+        "hours": 1,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "2810",
+        "title": "Super Cereal",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2808",
+        "title": "Super Shelter Pets",
+        "hours": 2,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2307",
+        "title": "Superhero Kits",
+        "hours": 5,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "40",
+        "title": "Supermarket Stakeout",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "12",
+                "name": "disasters"
+            },
+            {
+                "id": "6",
+                "name": "homelessness"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "47",
+        "title": "Support Board",
+        "hours": 2,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "start something"
+    },
+    {
+        "id": "2012",
+        "title": "Support for Survivors",
+        "hours": 2,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "5236",
+        "title": "Suspended for WHAT?: Amplify",
+        "hours": 0.5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "5234",
+        "title": "Suspended for WHAT?: Create",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "2016",
+        "title": "T-Shirt Takeover",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "3276",
+        "title": "Tackle Hunger",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2043",
+        "title": "Take Back the Streets",
+        "hours": 1,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "19",
+                "name": "mental health"
+            },
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3331",
+        "title": "Talk Dirty to Me",
+        "hours": 1,
+        "primary_cause": "sex",
+        "secondary_causes": [
+            {
+                "id": "21",
+                "name": "relationships"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "1144",
+        "title": "Teens for Jeans",
+        "hours": 10,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "2290",
+        "title": "Tell It With a Tiara",
+        "hours": 0.5,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "4140",
+        "title": "The Bully Project",
+        "hours": 0.5,
+        "primary_cause": "bullying",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "3108",
+        "title": "The Hunt",
+        "hours": 0,
+        "primary_cause": "",
+        "secondary_causes": [],
+        "action_type": ""
+    },
+    {
+        "id": "50",
+        "title": "Throwback Game Night",
+        "hours": 10,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            },
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3543",
+        "title": "Throwing Back Thanks",
+        "hours": 5,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "1508",
+        "title": "Thumb Wars",
+        "hours": 0.5,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "1357",
+        "title": "Tighty Whitey Rally",
+        "hours": 10,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "3504",
+        "title": "Trash or Treat",
+        "hours": 5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2929",
+        "title": "Trash Scavenger Hunt",
+        "hours": 2,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "876",
+        "title": "Trash Stash",
+        "hours": 10,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "836",
+        "title": "Trash-Free Tailgate",
+        "hours": 1,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "1538",
+        "title": "Treats for Troops",
+        "hours": 5,
+        "primary_cause": "mental health",
+        "secondary_causes": [
+            {
+                "id": "19",
+                "name": "mental health"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3534",
+        "title": "Trick-or-Treat for TP",
+        "hours": 5,
+        "primary_cause": "poverty",
+        "secondary_causes": [
+            {
+                "id": "15",
+                "name": "poverty"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "3559",
+        "title": "Turn Down for Sexism",
+        "hours": 0.5,
+        "primary_cause": "violence",
+        "secondary_causes": [
+            {
+                "id": "14",
+                "name": "discrimination"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            },
+            {
+                "id": "17",
+                "name": "violence"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2299",
+        "title": "Two Books Blue Books",
+        "hours": 10,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "donate something"
+    },
+    {
+        "id": "33",
+        "title": "Unban Underpants!",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "take a stand"
+    },
+    {
+        "id": "946",
+        "title": "Update Your Status",
+        "hours": 1,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            },
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2535",
+        "title": "Veggie Surprise",
+        "hours": 5,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "2089",
+        "title": "Visionary Volunteer",
+        "hours": 1,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "face to face"
+    },
+    {
+        "id": "4532",
+        "title": "Vote Up or Shut Up",
+        "hours": 2,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "5438",
+        "title": "We Are Able",
+        "hours": 0.5,
+        "primary_cause": "discrimination",
+        "secondary_causes": [
+            {
+                "id": "13",
+                "name": "bullying"
+            },
+            {
+                "id": "14",
+                "name": "discrimination"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "854",
+        "title": "Week Without Oil",
+        "hours": 1,
+        "primary_cause": "environment",
+        "secondary_causes": [
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "improve a space"
+    },
+    {
+        "id": "1662",
+        "title": "Welcome Home",
+        "hours": 1,
+        "primary_cause": "homelessness",
+        "secondary_causes": [
+            {
+                "id": "6",
+                "name": "homelessness"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "3435",
+        "title": "Whole New Ball Game",
+        "hours": 2,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    },
+    {
+        "id": "689",
+        "title": "Wildlife Cards",
+        "hours": 1,
+        "primary_cause": "animals",
+        "secondary_causes": [
+            {
+                "id": "16",
+                "name": "animals"
+            },
+            {
+                "id": "4",
+                "name": "environment"
+            }
+        ],
+        "action_type": "make something"
+    },
+    {
+        "id": "4551",
+        "title": "Would You Rather?",
+        "hours": 0,
+        "primary_cause": "education",
+        "secondary_causes": [
+            {
+                "id": "2",
+                "name": "education"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "2900",
+        "title": "You’re Doing It Wrong",
+        "hours": 0.5,
+        "primary_cause": "sex",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            },
+            {
+                "id": "1",
+                "name": "sex"
+            }
+        ],
+        "action_type": "share something"
+    },
+    {
+        "id": "38",
+        "title": "Zombie Blood Drive",
+        "hours": 10,
+        "primary_cause": "physical health",
+        "secondary_causes": [
+            {
+                "id": "5",
+                "name": "physical health"
+            }
+        ],
+        "action_type": "host an event"
+    }
+]
+
+}

--- a/lib/campaign_import.js
+++ b/lib/campaign_import.js
@@ -1,14 +1,23 @@
-//TODO: Have a 'dev' option to just load a file containing campaign data
-
 var CAMPAIGN_URL = "https://www.dosomething.org/api/v1/campaigns";
 
+var config = require("../config.json");
 var request = require('superagent');
 var callback;
 var tempCampaigns = [];
 
 module.exports = function(call) {
   callback = call;
-  fetchCampaigns();
+  if(config.import_campaigns) {
+    fetchCampaigns();
+  }
+  else{
+    loadFromFile();
+  }
+}
+
+function loadFromFile() {
+  var campaigns = require("../debug_campaigns.json").campaigns;
+  callback(campaigns);
 }
 
 function fetchCampaigns(customUrl) {


### PR DESCRIPTION
Used in local dev to have instant startup rather than waiting a few seconds for polling the API. 

Not storing this in Mongo because I'm trying to avoid maintaining two large databases with all of our campaigns. Mongo will just store the campaigns which have been scheduled. 

@sbsmith86 are you okay with this implementation / idea? 
